### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-dev-release.yml
+++ b/.github/workflows/publish-dev-release.yml
@@ -1,4 +1,6 @@
 name: Publish development release
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/LRC-Editor/security/code-scanning/1](https://github.com/FlutterGenerator/LRC-Editor/security/code-scanning/1)

The best way to fix this problem is to explicitly declare a `permissions` block in the workflow YAML. For this workflow, the only operations interacting with GitHub are the release creation and deletion, which require `contents: write`. To follow least privilege, we should only grant what's needed: `contents: write` for releases. You should add a `permissions` section at the top-level of the workflow (above `jobs:`) so it applies to all jobs (or at the job level if finer control is required). No other permissions seem to be necessary for this workflow, so do not grant additional access (e.g., to issues or pull-requests).

Add the following lines near the top of `.github/workflows/publish-dev-release.yml`, after the `name` directive and before `on:`:

```yaml
permissions:
  contents: write
```

No other changes (imports etc.) are needed for this YAML workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
